### PR TITLE
fix: load js file correctly

### DIFF
--- a/Sources/web3swift/Browser/BrowserViewController.swift
+++ b/Sources/web3swift/Browser/BrowserViewController.swift
@@ -35,12 +35,18 @@ open class BrowserViewController: UIViewController {
         return webView
     }()
     
+    private var bundle: Bundle {
+        Bundle(for: BrowserViewController.self)
+    }
+
     lazy var config: WKWebViewConfiguration = {
         let config = WKWebViewConfiguration()
-        
+
         var js = ""
-        
-        if let filepath = Bundle.main.path(forResource: "browser.min", ofType: "js") {
+
+        let bundleURL = bundle.bundleURL.appendingPathComponent("Browser.bundle")
+        if let scripteBundle = Bundle(url: bundleURL),
+           let filepath = scripteBundle.path(forResource: "browser.min", ofType: "js") {
             do {
                 js += try String(contentsOfFile: filepath)
                 NSLog("Loaded browser.js")


### PR DESCRIPTION
The origin implement can't load `js` file correctly when being added as a `CocoaPods` dependency or a Swift Package.